### PR TITLE
Fix ClassCastException: int to bouble

### DIFF
--- a/app/src/androidTest/java/com/marcosholgado/performancetest/sixthtest/ActivityPerfTestRule.kt
+++ b/app/src/androidTest/java/com/marcosholgado/performancetest/sixthtest/ActivityPerfTestRule.kt
@@ -37,7 +37,8 @@ open class ActivityPerfTestRule<T: Activity>(activityClass: Class<T>): ActivityT
     override fun afterActivityFinished() {
         monitor?.let {
             val results = it.stopIteration()
-            val res: Double = results?.get(annotation?.perfType?.type) as Double
+            val type = annotation?.perfType?.type
+            val res: Double = results.getDouble(type, results.getInt(type).toDouble())
 
             val assertion = when(annotation?.assertionType) {
                 PerformanceTest.AssertionType.LESS -> res < annotation!!.threshold
@@ -50,7 +51,7 @@ open class ActivityPerfTestRule<T: Activity>(activityClass: Class<T>): ActivityT
             TestCase.assertTrue(
                 String.format(
                     "Monitor: %s, Expected: %d, Received: %f.",
-                    annotation?.perfType?.type, annotation!!.threshold,
+                    type, annotation!!.threshold,
                     res
                 ),
                 assertion


### PR DESCRIPTION
`stopIteration` returns `Bundle` which may contain `Double` or `Integer` values. `results?.get(annotation?.perfType?.type) as Double` throws an exception in case of integer value.

Fix checks if there is int or double and sets one of them to `res` value.
```
E/TestRunner: failed: testSixth(com.elevenetc.android.flat.performance.SixthTest)
    ----- begin exception -----
E/TestRunner: java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Double
        at com.elevenetc.android.flat.performance.ActivityPerfTestRule.afterActivityFinished(ActivityPeftTestRule.kt:41)
        at androidx.test.rule.ActivityTestRule.finishActivity(ActivityTestRule.java:397)
        at androidx.test.rule.ActivityTestRule$ActivityStatement.evaluate(ActivityTestRule.java:539)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.junit.runners.Suite.runChild(Suite.java:128)
        at org.junit.runners.Suite.runChild(Suite.java:27)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
        at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
        at androidx.test.internal.runner.TestExecutor.execute(TestExecutor.java:56)
        at androidx.test.runner.AndroidJUnitRunner.onStart(AndroidJUnitRunner.java:392)
        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:2379)
    ----- end exception -----
```